### PR TITLE
feat: export types, convert to default export

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,16 +7,16 @@ enum LogLevel {
   ERROR,
 }
 
-interface ILogContext {
+export interface ILogContext {
   [key: string]: any
 }
 
-interface ILogDefaults {
+export interface ILogDefaults {
   context: ILogContext
   tag?: string
 }
 
-interface ILogFormatInput {
+export interface ILogFormatInput {
   context?: ILogContext
   defaults: ILogDefaults
   label: string
@@ -24,11 +24,11 @@ interface ILogFormatInput {
   timestamp: number
 }
 
-interface ILogFormatFunction {
+export interface ILogFormatFunction {
   (input: ILogFormatInput): string
 }
 
-interface ILogFunction {
+export interface ILogFunction {
   (message: string, context?: ILogContext): void
 }
 
@@ -135,4 +135,4 @@ log.untag = () => {
   delete defaults.tag
 }
 
-export = log
+export default log


### PR DESCRIPTION
To use the custom format function, it is very helpful to have access to the types provided by the package.

To export the types the module also had to be converted into an ES6 module, which is a breaking change in some cases.